### PR TITLE
Add README.md and update license in Cargo.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# Algorithms Practice
+
+This repository contains a collection of algorithmic exercises and solutions implemented in various programming languages. It is organized to help me practice, learn, and master fundamental algorithms and data structures through hands-on coding.
+
+## Structure
+
+- `exercises/` — Contains subdirectories for each algorithmic problem or topic, with language-specific folders (e.g., `rust/`).
+- Each exercise will eventually include:
+  - Problem description (in code comments or a local README)
+  - One or more implementations
+  - Unit tests and/or property-based tests
+
+## Languages Used
+- Rust (primary)
+- Python
+
+## How to Use
+1. Clone the repository:
+   ```sh
+   git clone https://github.com/butterflysky/algorithms-practice.git
+   cd algorithms-practice
+   ```
+2. Navigate to an exercise and follow the instructions in its subdirectory.
+3. For Rust exercises:
+   ```sh
+   cd exercises/<exercise-name>/rust
+   cargo test
+   ```
+4. To add a new Rust crate, use the Cargo workspace setup:
+   ```sh
+   cargo workspaces create --lib --name <new-exercise-name> exercises/<new-exercise-name>/rust
+   # or for a binary crate:
+   cargo workspaces create --bin --name <new-exercise-name> exercises/<new-exercise-name>/rust
+   # The glob in workspace members in exercises/Cargo.toml will capture the new crate automatically
+   ```
+   This repository uses a Cargo workspace, so new crates should be created with `cargo workspaces create`, rather than using `cargo init` inside an existing directory.
+
+## License
+This project is licensed under the MIT License. See the `LICENSE` file for details.

--- a/exercises/Cargo.toml
+++ b/exercises/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "3"
 authors = ["butterflysky <bright.art1794@fastmail.com>"]
 description = "Part of a collection of practice exercises I'm doing to learn Rust"
 edition = "2024"
-license = "MIT OR Apache-2.0"
+license = "MIT"
 version = "0.1.0"
 
 [workspace.dependencies]


### PR DESCRIPTION
Introduce a README.md to provide an overview of the repository and its structure, and simplify the license specification in Cargo.toml to MIT only.