### PR TITLE
Improve error handling and test case clarity for string_encode_and_decode

### DIFF
--- a/exercises/string_encode_and_decode/rust/src/errors.rs
+++ b/exercises/string_encode_and_decode/rust/src/errors.rs
@@ -28,7 +28,7 @@ impl fmt::Display for DecodeError {
                 f.write_str("String payload cut off before expected length")
             },
             Self::Utf8(e) => {
-                f.write_str(format!("UTF-8 Parsing error: {}", e).as_str())
+                write!(f, "UTF-8 Parsing error: {}", e)
             }
         }
     }

--- a/exercises/string_encode_and_decode/rust/src/lib.rs
+++ b/exercises/string_encode_and_decode/rust/src/lib.rs
@@ -114,7 +114,7 @@ mod tests {
 
     fn get_simple_test_tuple() -> (Vec<String>, String, String) {
         let input = vec!["hi".to_owned(), "there".to_owned()];
-        (input.clone(), "\02\0hi\05\0there".to_owned(), encode(input))
+        (input.clone(), "\x002\x00hi\x005\x00there".to_owned(), encode(input))
     }
 
     #[test]
@@ -143,7 +143,7 @@ mod tests {
         let result = encode(vec!["".to_owned()]);
         let mut expected: String = String::with_capacity(3);
 
-        expected.push_str("\00\0");
+        expected.push_str("\x000\x00");
 
         assert_eq!(expected.len(), 3);
         assert_eq!(result, expected);


### PR DESCRIPTION
Address unnecessary memory allocation in the `DecodeError` implementation and enhance the legibility of test cases by using more explicit string representations.