### PR TITLE
Add documentation to string_encode_and_decode

### DIFF
--- a/exercises/string_encode_and_decode/rust/src/errors.rs
+++ b/exercises/string_encode_and_decode/rust/src/errors.rs
@@ -1,13 +1,31 @@
 use std::error::Error;
 use std::fmt;
 
+/// Errors that can occur during decoding of an encoded string.
+///
+/// This enum represents all possible error conditions that may arise when
+/// attempting to decode a string produced by the [`crate::encode`] function.
+///
+/// Variants:
+/// - [`DecodeError::SentinelNotFound`]: The expected sentinel character (`\0`) was not found at the correct position.
+/// - [`DecodeError::LengthMarkerCorrupt`]: The length marker was missing, malformed, or could not be parsed.
+/// - [`DecodeError::LengthOverflow`]: The decoded string exceeded the expected length specified by the marker.
+/// - [`DecodeError::NonDigitInLengthMarker`]: A non-ASCII digit was encountered in the length marker.
+/// - [`DecodeError::Truncated`]: The encoded string ended before the expected number of bytes for a string.
+/// - [`DecodeError::Utf8`]: The decoded bytes could not be converted to a valid UTF-8 string.
 #[derive(Debug)]
 pub enum DecodeError {
+    /// The expected sentinel character (`\0`) was not found.
     SentinelNotFound(),
+    /// The length marker was missing or malformed.
     LengthMarkerCorrupt(),
+    /// The decoded string exceeded the expected length.
     LengthOverflow(),
+    /// A non-ASCII digit was found in the length marker.
     NonDigitInLengthMarker(),
+    /// The encoded string ended before the expected number of bytes.
     Truncated(),
+    /// The decoded bytes could not be converted to a valid UTF-8 string.
     Utf8(std::str::Utf8Error),
 }
 


### PR DESCRIPTION
Enhance the documentation for the string encoding and decoding module, including detailed explanations of functions, error types, and usage examples. 